### PR TITLE
Switch to Resampling.LANCZOS

### DIFF
--- a/generate_smallvariants.py
+++ b/generate_smallvariants.py
@@ -23,7 +23,7 @@ def generate_smallvariants(resource):
         with Image.open(os.path.join(wallpapers_path, wallpaper)) as img:
             size = int(img.width / 4), int(img.height / 4)
 
-            img_small = img.resize(size, Image.ANTIALIAS)
+            img_small = img.resize(size, Image.Resampling.LANCZOS)
             img_small.save(wallpaper_small_path, "JPEG")
 
 def clean(wallpapers_path):


### PR DESCRIPTION
generate_smallvariants.py:26: DeprecationWarning:
ANTIALIAS is deprecated and will be removed in Pillow 10 (2023-07-01). Use LANCZOS or Resampling.LANCZOS instead.

Change-Id: I2d317afb47af9164d3d6c359fe6c197196bdd24d